### PR TITLE
Fixed the initialization of counter in MicroTime

### DIFF
--- a/lib/RandomLib/Source/MicroTime.php
+++ b/lib/RandomLib/Source/MicroTime.php
@@ -71,9 +71,9 @@ final class MicroTime implements \RandomLib\Source {
         $state      .= serialize(debug_backtrace(false));
         self::$state = hash('sha512', $state, true);
         if (is_null(self::$counter)) {
-            self::$counter = bindec(substr(self::$state, 0, 4));
+            list( , self::$counter) = unpack("i", substr(self::$state, 0, 4));
             $seed = $this->generate(strlen(dechex(PHP_INT_MAX)));
-            self::$counter = bindec($seed);
+            list( , self::$counter) = unpack("i", $seed);
         }
     }
 

--- a/test/Unit/RandomLib/Source/MicroTimeTest.php
+++ b/test/Unit/RandomLib/Source/MicroTimeTest.php
@@ -17,6 +17,16 @@ class MicroTimeTest extends \PHPUnit_Framework_TestCase {
         return $data;
     }
 
+    /** 
+     * Test the initialization of the static counter (!== 0)
+     */
+    public function testCounterNotNull() {
+        $rand = new MicroTime;
+        $reflection_class = new \ReflectionClass("RandomLib\Source\MicroTime");
+        $static = $reflection_class->getStaticProperties();
+        $this->assertTrue($static['counter'] !== 0);
+    }
+    
     /**
      */
     public function testGetStrength() {


### PR DESCRIPTION
The static $counter in RandomLib\Source\Microtime is always equal to zero at the end of __construct. I tested with a 64bit Linux environment running PHP 5.3.10.
This comes because bindec() that doesn't work fine on this environment. I replaced it using unpack(). I also provided a Unit Test to cover this behaviour.
