### PR TITLE
Semantic Versioning

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,5 +25,10 @@
         "psr-0": {
             "RandomLib":   "lib"
         }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0.x-dev"
+        }
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,5 +1,9 @@
 {
-    "hash": "fc0152cc930dfe3d647e17cd31b0d3a9",
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file"
+    ],
+    "hash": "21fb1d739216a092f14e061636416096",
     "packages": [
         {
             "name": "ircmaxell/security-lib",
@@ -21,7 +25,6 @@
             "require-dev": {
                 "mikey179/vfsstream": "1.1.*"
             },
-            "time": "2013-02-13 17:23:59",
             "type": "library",
             "autoload": {
                 "psr-0": {
@@ -40,15 +43,53 @@
                 }
             ],
             "description": "A Base Security Library",
-            "homepage": "https://github.com/ircmaxell/PHP-SecurityLib"
+            "homepage": "https://github.com/ircmaxell/PHP-SecurityLib",
+            "time": "2013-02-13 17:23:59"
         }
     ],
-    "packages-dev": null,
+    "packages-dev": [
+        {
+            "name": "mikey179/vfsStream",
+            "version": "v1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mikey179/vfsStream",
+                "reference": "v1.1.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://github.com/mikey179/vfsStream/zipball/v1.1.0",
+                "reference": "v1.1.0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "org\\bovigo\\vfs": "src/main/php"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD"
+            ],
+            "homepage": "http://vfs.bovigo.org/",
+            "time": "2012-08-25 05:49:29"
+        }
+    ],
     "aliases": [
 
     ],
     "minimum-stability": "dev",
     "stability-flags": {
         "ircmaxell/security-lib": 20
-    }
+    },
+    "platform": {
+        "php": ">=5.3.2"
+    },
+    "platform-dev": [
+
+    ]
 }


### PR DESCRIPTION
Ensure that people can start requiring "ircmaxell/random-lib" using semantic versioning like the following instead of forcing people to use `dev-master` as the version:

```
"ircmaxell/random-lib": "1.*@dev"
```

An unintended side effect of composer.json changes is that it results in composer.lock needing to change to account for a different hash. In addition, Composer sometimes actually changes other aspects of the composer.lock
structure.

---

Somewhat related, I'm going to follow up on security-lib and see how/why `dev-master` is required there. I see there is 1.0.x-dev branch but also dev-master. I'm not sure if dev-master is newer? Or older? How does it relate to 1.0.x-dev? I'm going to guess that dev-master is actually supposed to mean something like 1.1.x-dev?

If master should be considered something like 1.1.x-dev I'll do something similar to what I'm doing here (adding a branch alias for dev-master => 1.1.x-dev) to get us to the point where we can require `1.1.*@dev` instead of `dev-master`. Then I'll make that change against RandomLib's composer.json.

If this sounds like a good plan to you, you can merge this now and then I can send another PR after we've worked through security-lib to require the new dev version instead of `dev-master`. Or if you prefer, you can just hold off on this PR and I can update it after we've handled the SecurityLib changes. I'm happy to go down either path. :) Just let me know how you'd like to move forward.
