### PR TITLE
Minor fix: Fixed homepage url

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "type": "library",
     "description": "A Library For Generating Secure Random Numbers",
     "keywords": ["random", "random-numbers", "random-strings", "cryptography"],
-    "homepage": "https://github.com/ircmaxell/PHP-RandomLib",
+    "homepage": "https://github.com/ircmaxell/RandomLib",
     "license": "MIT",
     "minimum-stability": "dev",
     "authors": [


### PR DESCRIPTION
The old homepage URL is no more. I guess the Github repo was renamed. This information is also reflected on https://packagist.org/packages/ircmaxell/random-lib.
