### PR TITLE
Returning result with only 1 character to choose from

### DIFF
--- a/lib/RandomLib/Generator.php
+++ b/lib/RandomLib/Generator.php
@@ -146,7 +146,7 @@ class Generator {
      * @return string The generated random string
      */
     public function generateString($length, $characters = '') {
-        if ($length == 0 || strlen($characters) == 1) {
+        if ($length == 0 || strlen($characters) == 0) {
             return '';
         } elseif (empty($characters)) {
             // Default to base 64


### PR DESCRIPTION
When string length > 1 (5) and only one character ('a') has been given the correct return value should be a string with only that character ('aaaaa'). Ok sure there is nothing random about that, but that's more likely a case to throw a logic exception or something similar.
