### PR TITLE
Suppress warning on servers with "open_basedir restriction in effect"

### DIFF
--- a/lib/RandomLib/Source/URandom.php
+++ b/lib/RandomLib/Source/URandom.php
@@ -54,7 +54,7 @@ class URandom implements \RandomLib\Source {
      * @return string A string of the requested size
      */
     public function generate($size) {
-        if ($size == 0 || !file_exists($this->file)) {
+        if ($size == 0 || !@file_exists($this->file)) {
             return str_repeat(chr(0), $size);
         }
         $file = fopen($this->file, 'rb');


### PR DESCRIPTION
Hi, 

On servers with "open_basedir restrictions", the function `file_exists()` throws a warning, instead of returning `false`, as it should do, IMHO. 
The problem is that users on these servers are also most likely not able to control the settings of the server, and as such, can't prevent these warnings themselves. 
It's really bad practice to suppress warnings with the `@`-operator, but as far as i know there's no proper way to circumvent these. For one, `is_readable()` throws the same warning. 

Full error message: 

```
Warning: file_exists() [function.file-exists]: open_basedir restriction in
effect. File(/dev/urandom) is not within the allowed path(s): (/usr/share/php:/f
oo/:/usr/share/pear:/usr/sbin:/usr/bin:/bin:/tmp:/etc/phpmyadmin:/usr/lib/php4:/
usr/lib/php5:/opt/ioncube/lib) in /foo/public_html/vendor/ircmaxell/random-
lib/lib/RandomLib/Source/URandom.php on line 57

Warning: Cannot modify header information - headers already sent by (output
started at /foo/public_html/vendor/ircmaxell/random-
lib/lib/RandomLib/Source/URandom.php:57) in
/foo/public_html/app/src/Bolt/Users.php on line 285 Redirecting to /beheer/.
```
