### PR TITLE
Prepare for 1.1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master":  "1.0.x-dev"
+            "dev-master":  "1.1.x-dev"
         }
     }
 }


### PR DESCRIPTION
Looking at the differences between 1.0.0 and master it seems as though there could be a case for bumping the minor version from 1.0 to 1.1 seeing as there was some refactoring and new things added (like a bunch of constants). This would be in preparation for tagging a new stable release. See #26 

In addition to merging this PR, I would first create a 1.0 branch off of master so that people can continue to target 1.0@dev.

@ircmaxell: If I can get a :+1: on this I'll put this all into motion. If anyone else wants to provide feedback on whether this warrants a minor version bump, feel free to chime in.