### PR TITLE
Added Source::isSupported()

### DIFF
--- a/lib/RandomLib/AbstractSource.php
+++ b/lib/RandomLib/AbstractSource.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * PHP version 5.3
+ *
+ * @category  PHPSecurityLib
+ * @package   Random
+ * @author    Anthony Ferrara <ircmaxell@ircmaxell.com>
+ * @copyright 2011 The Authors
+ * @license    http://www.opensource.org/licenses/mit-license.html  MIT License
+ * @version   Build @@version@@
+ */
+
+namespace RandomLib;
+
+use SecurityLib\Strength;
+
+/**
+ * An abstract mixer to implement a common mixing strategy
+ *
+ * @category PHPSecurityLib
+ * @package  Random
+ */
+abstract class AbstractSource implements \RandomLib\Source {
+
+    /**
+     * Return an instance of Strength indicating the strength of the source
+     *
+     * @return Strength An instance of one of the strength classes
+     */
+    public static function getStrength() {
+        return new Strength(Strength::VERYLOW);
+    }
+
+    /**
+     * If the source is currently available.
+     * Reasons might be because the library is not installed
+     *
+     * @return boolean
+     */
+    public static function isSupported() {
+        return true;
+    }
+
+    /**
+     * Returns a string of zeroes, useful when no entropy is available.
+     *
+     * @param int $size The size of the requested random string
+     *
+     * @return string A string of the requested size
+     */
+    protected static function emptyValue($size) {
+        return str_repeat(chr(0), $size);
+    }
+
+}

--- a/lib/RandomLib/AbstractSource.php
+++ b/lib/RandomLib/AbstractSource.php
@@ -25,7 +25,7 @@ abstract class AbstractSource implements \RandomLib\Source {
     /**
      * Return an instance of Strength indicating the strength of the source
      *
-     * @return Strength An instance of one of the strength classes
+     * @return \SecurityLib\Strength An instance of one of the strength classes
      */
     public static function getStrength() {
         return new Strength(Strength::VERYLOW);

--- a/lib/RandomLib/Factory.php
+++ b/lib/RandomLib/Factory.php
@@ -58,15 +58,9 @@ class Factory extends \SecurityLib\AbstractFactory {
      * @throws RuntimeException If an appropriate mixing strategy isn't found
      */
     public function getGenerator(\SecurityLib\Strength $strength) {
-        $sources    = $this->getSources();
-        $newSources = array();
-        foreach ($sources as $source) {
-            if ($strength->compare($source::getStrength()) <= 0) {
-                $newSources[] = new $source;
-            }
-        }
-        $mixer = $this->findMixer($strength);
-        return new Generator($newSources, $mixer);
+        $sources = $this->findSources($strength);
+        $mixer   = $this->findMixer($strength);
+        return new Generator($sources, $mixer);
     }
 
     /**
@@ -162,6 +156,29 @@ class Factory extends \SecurityLib\AbstractFactory {
             $class
         );
         return $this;
+    }
+
+    /**
+     * Find a sources based upon the requested strength
+     *
+     * @param Strength $strength The strength mixer to find
+     *
+     * @return Source The found source
+     * @throws RuntimeException if a valid source cannot be found
+     */
+    protected function findSources(\SecurityLib\Strength $strength) {
+        $sources = array();
+        foreach ($this->getSources() as $source) {
+            if ($strength->compare($source::getStrength()) <= 0 && $source::isSupported()) {
+                $sources[] = new $source;
+            }
+        }
+
+        if (0 === count($sources)) {
+            throw new \RuntimeException('Could not find sources');
+        }
+
+        return $sources;
     }
 
     /**

--- a/lib/RandomLib/Mixer.php
+++ b/lib/RandomLib/Mixer.php
@@ -31,7 +31,7 @@ interface Mixer {
     /**
      * Return an instance of Strength indicating the strength of the mixer
      *
-     * @return Strength An instance of one of the strength classes
+     * @return \SecurityLib\Strength An instance of one of the strength classes
      */
     public static function getStrength();
 

--- a/lib/RandomLib/Mixer/Hash.php
+++ b/lib/RandomLib/Mixer/Hash.php
@@ -54,7 +54,7 @@ class Hash extends \RandomLib\AbstractMixer {
     /**
      * Return an instance of Strength indicating the strength of the source
      *
-     * @return Strength An instance of one of the strength classes
+     * @return \SecurityLib\Strength An instance of one of the strength classes
      */
     public static function getStrength() {
         return new Strength(Strength::MEDIUM);

--- a/lib/RandomLib/Source.php
+++ b/lib/RandomLib/Source.php
@@ -36,6 +36,14 @@ interface Source {
     public static function getStrength();
 
     /**
+     * If the source is currently available.
+     * Reasons might be because the library is not installed
+     *
+     * @return boolean
+     */
+    public static function isSupported();
+
+    /**
      * Generate a random string of the specified size
      *
      * Note: If the source fails to generate enough data, the result must be

--- a/lib/RandomLib/Source.php
+++ b/lib/RandomLib/Source.php
@@ -31,7 +31,7 @@ interface Source {
     /**
      * Return an instance of Strength indicating the strength of the source
      *
-     * @return Strength An instance of one of the strength classes
+     * @return \SecurityLib\Strength An instance of one of the strength classes
      */
     public static function getStrength();
 

--- a/lib/RandomLib/Source/CAPICOM.php
+++ b/lib/RandomLib/Source/CAPICOM.php
@@ -35,7 +35,7 @@ class CAPICOM extends \RandomLib\AbstractSource {
     /**
      * Return an instance of Strength indicating the strength of the source
      *
-     * @return Strength An instance of one of the strength classes
+     * @return \SecurityLib\Strength An instance of one of the strength classes
      */
     public static function getStrength() {
         return new Strength(Strength::MEDIUM);

--- a/lib/RandomLib/Source/CAPICOM.php
+++ b/lib/RandomLib/Source/CAPICOM.php
@@ -30,7 +30,7 @@ use SecurityLib\Strength;
  * @author     Anthony Ferrara <ircmaxell@ircmaxell.com>
  * @codeCoverageIgnore
  */
-class CAPICOM implements \RandomLib\Source {
+class CAPICOM extends \RandomLib\AbstractSource {
 
     /**
      * Return an instance of Strength indicating the strength of the source
@@ -42,6 +42,16 @@ class CAPICOM implements \RandomLib\Source {
     }
 
     /**
+     * If the source is currently available.
+     * Reasons might be because the library is not installed
+     *
+     * @return boolean
+     */
+    public static function isSupported() {
+        return class_exists('\\COM', false);
+    }
+
+    /**
      * Generate a random string of the specified size
      *
      * @param int $size The size of the requested random string
@@ -49,16 +59,13 @@ class CAPICOM implements \RandomLib\Source {
      * @return string A string of the requested size
      */
     public function generate($size) {
-        if (!class_exists('\\COM', false)) {
-            return str_repeat(chr(0), $size);
-        }
         try {
             $util = new \COM('CAPICOM.Utilities.1');
             $data = base64_decode($util->GetRandom($size, 0));
             return str_pad($data, $size, chr(0));
         } catch (\Exception $e) {
             unset($e);
-            return str_repeat(chr(0), $size);
+            return static::emptyValue($size);
         }
     }
 

--- a/lib/RandomLib/Source/MTRand.php
+++ b/lib/RandomLib/Source/MTRand.php
@@ -34,7 +34,7 @@ use SecurityLib\Strength;
  * @author     Anthony Ferrara <ircmaxell@ircmaxell.com>
  * @codeCoverageIgnore
  */
-class MTRand implements \RandomLib\Source {
+class MTRand extends \RandomLib\AbstractSource {
 
     /**
      * Return an instance of Strength indicating the strength of the source

--- a/lib/RandomLib/Source/MTRand.php
+++ b/lib/RandomLib/Source/MTRand.php
@@ -39,7 +39,7 @@ class MTRand extends \RandomLib\AbstractSource {
     /**
      * Return an instance of Strength indicating the strength of the source
      *
-     * @return Strength An instance of one of the strength classes
+     * @return \SecurityLib\Strength An instance of one of the strength classes
      */
     public static function getStrength() {
         // Detect if Suhosin Hardened PHP patch is applied

--- a/lib/RandomLib/Source/MicroTime.php
+++ b/lib/RandomLib/Source/MicroTime.php
@@ -34,7 +34,7 @@ use SecurityLib\Strength;
  * @author     Anthony Ferrara <ircmaxell@ircmaxell.com>
  * @codeCoverageIgnore
  */
-final class MicroTime implements \RandomLib\Source {
+final class MicroTime extends \RandomLib\AbstractSource {
 
     /**
      * A static counter to ensure unique hashes and prevent state collisions
@@ -47,15 +47,6 @@ final class MicroTime implements \RandomLib\Source {
      * @var string The state of the PRNG
      */
     private static $state = '';
-
-    /**
-     * Return an instance of Strength indicating the strength of the source
-     *
-     * @return Strength An instance of one of the strength classes
-     */
-    public static function getStrength() {
-        return new Strength(Strength::VERYLOW);
-    }
 
     public function __construct() {
         $state = self::$state;

--- a/lib/RandomLib/Source/OpenSSL.php
+++ b/lib/RandomLib/Source/OpenSSL.php
@@ -30,7 +30,7 @@ use SecurityLib\Strength;
  * @author     Anthony Ferrara <ircmaxell@ircmaxell.com>
  * @codeCoverageIgnore
  */
-class OpenSSL implements \RandomLib\Source {
+class OpenSSL extends \RandomLib\AbstractSource {
 
     /**
      * Return an instance of Strength indicating the strength of the source
@@ -42,6 +42,16 @@ class OpenSSL implements \RandomLib\Source {
     }
 
     /**
+     * If the source is currently available.
+     * Reasons might be because the library is not installed
+     *
+     * @return boolean
+     */
+    public static function isSupported() {
+        return function_exists('openssl_random_pseudo_bytes');
+    }
+
+    /**
      * Generate a random string of the specified size
      *
      * @param int $size The size of the requested random string
@@ -49,7 +59,7 @@ class OpenSSL implements \RandomLib\Source {
      * @return string A string of the requested size
      */
     public function generate($size) {
-        if (!function_exists('openssl_random_pseudo_bytes') || $size < 1) {
+        if ($size < 1) {
             return str_repeat(chr(0), $size);
         }
         /**

--- a/lib/RandomLib/Source/OpenSSL.php
+++ b/lib/RandomLib/Source/OpenSSL.php
@@ -35,7 +35,7 @@ class OpenSSL extends \RandomLib\AbstractSource {
     /**
      * Return an instance of Strength indicating the strength of the source
      *
-     * @return Strength An instance of one of the strength classes
+     * @return \SecurityLib\Strength An instance of one of the strength classes
      */
     public static function getStrength() {
         return new Strength(Strength::HIGH);

--- a/lib/RandomLib/Source/Rand.php
+++ b/lib/RandomLib/Source/Rand.php
@@ -39,7 +39,7 @@ class Rand extends \RandomLib\AbstractSource {
     /**
      * Return an instance of Strength indicating the strength of the source
      *
-     * @return Strength An instance of one of the strength classes
+     * @return \SecurityLib\Strength An instance of one of the strength classes
      */
     public static function getStrength() {
         // Detect if Suhosin Hardened PHP patch is applied

--- a/lib/RandomLib/Source/Rand.php
+++ b/lib/RandomLib/Source/Rand.php
@@ -34,7 +34,7 @@ use SecurityLib\Strength;
  * @author     Anthony Ferrara <ircmaxell@ircmaxell.com>
  * @codeCoverageIgnore
  */
-class Rand implements \RandomLib\Source {
+class Rand extends \RandomLib\AbstractSource {
 
     /**
      * Return an instance of Strength indicating the strength of the source

--- a/lib/RandomLib/Source/Random.php
+++ b/lib/RandomLib/Source/Random.php
@@ -35,7 +35,7 @@ class Random extends URandom {
     /**
      * @var string The file to read from
      */
-    protected $file = '/dev/random';
+    protected static $file = '/dev/random';
 
     /**
      * Return an instance of Strength indicating the strength of the source

--- a/lib/RandomLib/Source/Random.php
+++ b/lib/RandomLib/Source/Random.php
@@ -40,7 +40,7 @@ class Random extends URandom {
     /**
      * Return an instance of Strength indicating the strength of the source
      *
-     * @return Strength An instance of one of the strength classes
+     * @return \SecurityLib\Strength An instance of one of the strength classes
      */
     public static function getStrength() {
         return new Strength(Strength::HIGH);

--- a/lib/RandomLib/Source/URandom.php
+++ b/lib/RandomLib/Source/URandom.php
@@ -40,7 +40,7 @@ class URandom extends \RandomLib\AbstractSource {
     /**
      * Return an instance of Strength indicating the strength of the source
      *
-     * @return Strength An instance of one of the strength classes
+     * @return \SecurityLib\Strength An instance of one of the strength classes
      */
     public static function getStrength() {
         return new Strength(Strength::MEDIUM);

--- a/lib/RandomLib/Source/URandom.php
+++ b/lib/RandomLib/Source/URandom.php
@@ -30,12 +30,12 @@ use SecurityLib\Strength;
  * @author     Anthony Ferrara <ircmaxell@ircmaxell.com>
  * @codeCoverageIgnore
  */
-class URandom implements \RandomLib\Source {
+class URandom extends \RandomLib\AbstractSource {
 
     /**
      * @var string The file to read from
      */
-    protected $file = '/dev/urandom';
+    protected static $file = '/dev/urandom';
 
     /**
      * Return an instance of Strength indicating the strength of the source
@@ -47,6 +47,17 @@ class URandom implements \RandomLib\Source {
     }
 
     /**
+     * If the source is currently available.
+     * Reasons might be because the library is not installed
+     *
+     * @return boolean
+     */
+    public static function isSupported()
+    {
+        return @file_exists(static::$file);
+    }
+
+    /**
      * Generate a random string of the specified size
      *
      * @param int $size The size of the requested random string
@@ -54,12 +65,12 @@ class URandom implements \RandomLib\Source {
      * @return string A string of the requested size
      */
     public function generate($size) {
-        if ($size == 0 || !@file_exists($this->file)) {
-            return str_repeat(chr(0), $size);
+        if ($size == 0) {
+            return static::emptyValue($size);
         }
-        $file = fopen($this->file, 'rb');
+        $file = fopen(static::$file, 'rb');
         if (!$file) {
-            return str_repeat(chr(0), $size);
+            return static::emptyValue($size);
         }
         if (function_exists('stream_set_read_buffer')) {
             stream_set_read_buffer($file, 0);

--- a/lib/RandomLib/Source/UniqID.php
+++ b/lib/RandomLib/Source/UniqID.php
@@ -37,7 +37,7 @@ class UniqID extends \RandomLib\AbstractSource {
     /**
      * Return an instance of Strength indicating the strength of the source
      *
-     * @return Strength An instance of one of the strength classes
+     * @return \SecurityLib\Strength An instance of one of the strength classes
      */
     public static function getStrength() {
         return new Strength(Strength::LOW);

--- a/lib/RandomLib/Source/UniqID.php
+++ b/lib/RandomLib/Source/UniqID.php
@@ -32,7 +32,7 @@ use SecurityLib\Strength;
  * @author     Anthony Ferrara <ircmaxell@ircmaxell.com>
  * @codeCoverageIgnore
  */
-class UniqID implements \RandomLib\Source {
+class UniqID extends \RandomLib\AbstractSource {
 
     /**
      * Return an instance of Strength indicating the strength of the source

--- a/test/Mocks/Random/Mixer.php
+++ b/test/Mocks/Random/Mixer.php
@@ -40,7 +40,7 @@ class Mixer extends \RandomLibTest\Mocks\AbstractMock implements \RandomLib\Mixe
     /**
      * Return an instance of Strength indicating the strength of the mixer
      *
-     * @return Strength An instance of one of the strength classes
+     * @return \SecurityLib\Strength An instance of one of the strength classes
      */
     public static function getStrength() {
         return static::$strength;

--- a/test/Mocks/Random/Source.php
+++ b/test/Mocks/Random/Source.php
@@ -38,7 +38,7 @@ class Source extends \RandomLibTest\Mocks\AbstractMock implements \RandomLib\Sou
     /**
      * Return an instance of Strength indicating the strength of the source
      *
-     * @return Strength An instance of one of the strength classes
+     * @return \SecurityLib\Strength An instance of one of the strength classes
      */
     public static function getStrength() {
         return static::$strength;

--- a/test/Mocks/Random/Source.php
+++ b/test/Mocks/Random/Source.php
@@ -43,7 +43,16 @@ class Source extends \RandomLibTest\Mocks\AbstractMock implements \RandomLib\Sou
     public static function getStrength() {
         return static::$strength;
     }
-        
+
+    /**
+     * If the source is currently available.
+     * Reasons might be because the library is not installed
+     *
+     * @return boolean
+     */
+    public static function isSupported() {
+        return true;
+    }
 
     /**
      * Generate a random string of the specified size

--- a/test/Unit/RandomLib/FactoryTest.php
+++ b/test/Unit/RandomLib/FactoryTest.php
@@ -25,6 +25,7 @@ class FactoryTest extends \PHPUnit_Framework_TestCase {
      * @covers RandomLib\Factory::getMediumStrengthGenerator
      * @covers RandomLib\Factory::getGenerator
      * @covers RandomLib\Factory::findMixer
+     * @covers RandomLib\Factory::findSources
      */
     public function testGetMediumStrengthGenerator() {
         $factory = new Factory;
@@ -41,5 +42,17 @@ class FactoryTest extends \PHPUnit_Framework_TestCase {
         }
     }
 
+    /**
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage Could not find sources
+     */
+    public function testNoAvailableSource()
+    {
+        $factory = new Factory;
+        $sources = new \ReflectionProperty($factory, 'sources');
+        $sources->setAccessible(true);
+        $sources->setValue($factory, array());
+        $factory->getMediumStrengthGenerator();
+    }
 
 }

--- a/test/Unit/RandomLib/Source/AbstractSourceTest.php
+++ b/test/Unit/RandomLib/Source/AbstractSourceTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace RandomLib\Source;
+
+use SecurityLib\Strength;
+
+abstract class AbstractSourceTest extends \PHPUnit_Framework_TestCase {
+
+    public function setUp()
+    {
+        $class = static::getTestedClass();
+
+        if (!$class::isSupported()) {
+            $this->markTestSkipped();
+        }
+    }
+
+    protected static function getTestedClass()
+    {
+        return preg_replace('/Test$/', '', get_called_class());
+    }
+
+    protected static function getExpectedStrength() {
+        return new Strength(Strength::VERYLOW);
+    }
+
+    public static function provideGenerate() {
+        $data = array();
+        for ($i = 0; $i < 100; $i += 5) {
+            $not = $i > 0 ? str_repeat(chr(0), $i) : chr(0);
+            $data[] = array($i, $not);
+        }
+        return $data;
+    }
+
+    public function testGetStrength() {
+        $class = static::getTestedClass();
+        $strength = static::getExpectedStrength();
+        $actual = $class::getStrength();
+        $this->assertEquals($actual, $strength);
+    }
+
+    /**
+     * @dataProvider provideGenerate
+     * @group slow
+     */
+    public function testGenerate($length, $not) {
+        $class = static::getTestedClass();
+        $rand = new $class;
+        $stub = $rand->generate($length);
+        $this->assertEquals($length, strlen($stub));
+        $this->assertNotEquals($not, $stub);
+    }
+
+}

--- a/test/Unit/RandomLib/Source/CAPICOMTest.php
+++ b/test/Unit/RandomLib/Source/CAPICOMTest.php
@@ -4,33 +4,10 @@ namespace RandomLib\Source;
 
 use SecurityLib\Strength;
 
-class CAPICOMTest extends \PHPUnit_Framework_TestCase {
+class CAPICOMTest extends AbstractSourceTest {
 
-    public static function provideGenerate() {
-        $data = array();
-        for ($i = 0; $i < 100; $i += 25) {
-            $not = $i > 0 ? str_repeat(chr(0), $i) : chr(0);
-            $data[] = array($i, $not);
-        }
-        return $data;
-    }
-
-    /**
-     */
-    public function testGetStrength() {
-        $strength = new Strength(Strength::MEDIUM);
-        $actual = CAPICOM::getStrength();
-        $this->assertEquals($actual, $strength);
-    }
-
-    /**
-     * @dataProvider provideGenerate
-     * @group slow
-     */
-    public function testGenerate($length, $not) {
-        $rand = new CAPICOM;
-        $stub = $rand->generate($length);
-        $this->assertEquals($length, strlen($stub));
+    protected static function getExpectedStrength() {
+        return new Strength(Strength::MEDIUM);
     }
 
 }

--- a/test/Unit/RandomLib/Source/MTRandTest.php
+++ b/test/Unit/RandomLib/Source/MTRandTest.php
@@ -4,39 +4,14 @@ namespace RandomLib\Source;
 
 use SecurityLib\Strength;
 
+class MTRandTest extends AbstractSourceTest {
 
-
-class MTRandTest extends \PHPUnit_Framework_TestCase {
-
-    public static function provideGenerate() {
-        $data = array();
-        for ($i = 0; $i < 100; $i += 5) {
-            $not = $i > 0 ? str_repeat(chr(0), $i) : chr(0);
-            $data[] = array($i, $not);
-        }
-        return $data;
-    }
-
-    /**
-     */
-    public function testGetStrength() {
+    protected static function getExpectedStrength() {
         if (defined('S_ALL')) {
-            $strength = new Strength(Strength::MEDIUM);
+            return new Strength(Strength::MEDIUM);
         } else {
-            $strength = new Strength(Strength::LOW);
+            return new Strength(Strength::LOW);
         }
-        $actual = MTRand::getStrength();
-        $this->assertEquals($actual, $strength);
-    }
-
-    /**
-     * @dataProvider provideGenerate
-     */
-    public function testGenerate($length, $not) {
-        $rand = new MTRand;
-        $stub = $rand->generate($length);
-        $this->assertEquals($length, strlen($stub));
-        $this->assertNotEquals($not, $stub);
     }
 
 }

--- a/test/Unit/RandomLib/Source/MicroTimeTest.php
+++ b/test/Unit/RandomLib/Source/MicroTimeTest.php
@@ -4,45 +4,21 @@ namespace RandomLib\Source;
 
 use SecurityLib\Strength;
 
+class MicroTimeTest extends AbstractSourceTest {
 
-
-class MicroTimeTest extends \PHPUnit_Framework_TestCase {
-
-    public static function provideGenerate() {
-        $data = array();
-        for ($i = 0; $i < 100; $i += 5) {
-            $not = $i > 0 ? str_repeat(chr(0), $i) : chr(0);
-            $data[] = array($i, $not);
-        }
-        return $data;
+    protected static function getExpectedStrength() {
+        return new Strength(Strength::VERYLOW);
     }
 
     /** 
      * Test the initialization of the static counter (!== 0)
      */
     public function testCounterNotNull() {
-        $rand = new MicroTime;
-        $reflection_class = new \ReflectionClass("RandomLib\Source\MicroTime");
+        $class = static::getTestedClass();
+        $rand = new $class;
+        $reflection_class = new \ReflectionClass($class);
         $static = $reflection_class->getStaticProperties();
         $this->assertTrue($static['counter'] !== 0);
-    }
-    
-    /**
-     */
-    public function testGetStrength() {
-        $strength = new Strength(Strength::VERYLOW);
-        $actual = MicroTime::getStrength();
-        $this->assertEquals($actual, $strength);
-    }
-
-    /**
-     * @dataProvider provideGenerate
-     */
-    public function testGenerate($length, $not) {
-        $rand = new MicroTime;
-        $stub = $rand->generate($length);
-        $this->assertEquals($length, strlen($stub));
-        $this->assertNotEquals($not, $stub);
     }
 
 }

--- a/test/Unit/RandomLib/Source/RandTest.php
+++ b/test/Unit/RandomLib/Source/RandTest.php
@@ -4,37 +4,14 @@ namespace RandomLib\Source;
 
 use SecurityLib\Strength;
 
-class RandTest extends \PHPUnit_Framework_TestCase {
+class RandTest extends AbstractSourceTest {
 
-    public static function provideGenerate() {
-        $data = array();
-        for ($i = 0; $i < 100; $i += 5) {
-            $not = $i > 0 ? str_repeat(chr(0), $i) : chr(0);
-            $data[] = array($i, $not);
-        }
-        return $data;
-    }
-
-    /**
-     */
-    public function testGetStrength() {
+    protected static function getExpectedStrength() {
         if (defined('S_ALL')) {
-            $strength = new Strength(Strength::LOW);
+            return new Strength(Strength::LOW);
         } else {
-            $strength = new Strength(Strength::VERYLOW);
+            return new Strength(Strength::VERYLOW);
         }
-        $actual = Rand::getStrength();
-        $this->assertEquals($actual, $strength);
-    }
-
-    /**
-     * @dataProvider provideGenerate
-     */
-    public function testGenerate($length, $not) {
-        $rand = new Rand;
-        $stub = $rand->generate($length);
-        $this->assertEquals($length, strlen($stub));
-        $this->assertNotEquals($not, $stub);
     }
 
 }

--- a/test/Unit/RandomLib/Source/URandomTest.php
+++ b/test/Unit/RandomLib/Source/URandomTest.php
@@ -4,40 +4,10 @@ namespace RandomLib\Source;
 
 use SecurityLib\Strength;
 
+class URandomTest extends AbstractSourceTest {
 
-
-class URandomTest extends \PHPUnit_Framework_TestCase {
-
-    public static function provideGenerate() {
-        $data = array();
-        for ($i = 0; $i < 10; $i += 5) {
-            $not = $i > 0 ? str_repeat(chr(0), $i) : chr(0);
-            $data[] = array($i, $not);
-        }
-        return $data;
-    }
-
-    /**
-     */
-    public function testGetStrength() {
-        $strength = new Strength(Strength::MEDIUM);
-        $actual = URandom::getStrength();
-        $this->assertEquals($actual, $strength);
-    }
-
-    /**
-     * @dataProvider provideGenerate
-     * @group slow
-     */
-    public function testGenerate($length, $not) {
-        $rand = new URandom;
-        $stub = $rand->generate($length);
-        $this->assertEquals($length, strlen($stub));
-        if (file_exists('/dev/urandom')) {
-            $this->assertNotEquals($not, $stub);
-        } else {
-            $this->assertEquals(str_repeat(chr(0), $length), $stub);
-        }
+    protected static function getExpectedStrength() {
+        return new Strength(Strength::MEDIUM);
     }
 
 }

--- a/test/Unit/RandomLib/Source/UniqIDTest.php
+++ b/test/Unit/RandomLib/Source/UniqIDTest.php
@@ -4,33 +4,10 @@ namespace RandomLib\Source;
 
 use SecurityLib\Strength;
 
-class UniqIDTest extends \PHPUnit_Framework_TestCase {
+class UniqIDTest extends AbstractSourceTest {
 
-    public static function provideGenerate() {
-        $data = array();
-        for ($i = 0; $i < 100; $i += 5) {
-            $not = $i > 0 ? str_repeat(chr(0), $i) : chr(0);
-            $data[] = array($i, $not);
-        }
-        return $data;
-    }
-
-    /**
-     */
-    public function testGetStrength() {
-        $strength = new Strength(Strength::LOW);
-        $actual = UniqID::getStrength();
-        $this->assertEquals($actual, $strength);
-    }
-
-    /**
-     * @dataProvider provideGenerate
-     */
-    public function testGenerate($length, $not) {
-        $rand = new UniqID;
-        $stub = $rand->generate($length);
-        $this->assertEquals($length, strlen($stub));
-        $this->assertNotEquals($not, $stub);
+    protected static function getExpectedStrength() {
+        return new Strength(Strength::LOW);
     }
 
 }


### PR DESCRIPTION
I noticed that when requiring high Strength, you may end up with no Source able to give you entropy and there is no warning, it simply returns the string full of null characters, which ends up being worse than asking for default Strength.

* Only loads a Source if it is supported
* Throws a RuntimeException if no Source is available for required Strength
* Added AbstractSource
  * Default Strength of VERYLOW.
  * Default isSupported() is true.
  * emptyValue function
* Added AbstractSourceTest for all Source tests
  * Figures out which class to test based on name
  * Marks test as skipped when isSupported is false.

**BC Break**: `Source` interface now requires a `isSupported` static function

P.s.: I tried replicating the code style the best I could, but you may consider switching to PSR-2.