### PR TITLE
Disable mcrypt mixer for PHP >= 7.1

### DIFF
--- a/lib/RandomLib/AbstractMcryptMixer.php
+++ b/lib/RandomLib/AbstractMcryptMixer.php
@@ -64,6 +64,11 @@ abstract class AbstractMcryptMixer extends AbstractMixer
      */
     public static function test()
     {
+        if (version_compare(PHP_VERSION, '7.1', '>=')) {
+            // https://wiki.php.net/rfc/mcrypt-viking-funeral
+            return false;
+        }
+
         return extension_loaded('mcrypt');
     }
 

--- a/test/Unit/RandomLib/Mixer/McryptRijndael128Test.php
+++ b/test/Unit/RandomLib/Mixer/McryptRijndael128Test.php
@@ -33,7 +33,7 @@ class McryptRijndael128Test extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        if (!extension_loaded('mcrypt')) {
+        if (!McryptRijndael128::test()) {
             $this->markTestSkipped('mcrypt extension is not available');
         }
     }


### PR DESCRIPTION
Mcrypt is deprecated as of PHP 7.1, as per:
https://wiki.php.net/rfc/mcrypt-viking-funeral

Fixes #55
