### PR TITLE
PHP 7.1 FIX: FUNCTION MCYRPT_XXX IS DEPRECATED

### DIFF
--- a/lib/RandomLib/AbstractMcryptMixer.php
+++ b/lib/RandomLib/AbstractMcryptMixer.php
@@ -72,9 +72,9 @@ abstract class AbstractMcryptMixer extends AbstractMixer
      */
     public function __construct()
     {
-        $this->mcrypt    = mcrypt_module_open($this->getCipher(), '', MCRYPT_MODE_ECB, '');
-        $this->blockSize = mcrypt_enc_get_block_size($this->mcrypt);
-        $this->initv     = str_repeat(chr(0), mcrypt_enc_get_iv_size($this->mcrypt));
+        $this->mcrypt    = @mcrypt_module_open($this->getCipher(), '', MCRYPT_MODE_ECB, '');
+        $this->blockSize = @mcrypt_enc_get_block_size($this->mcrypt);
+        $this->initv     = str_repeat(chr(0), @mcrypt_enc_get_iv_size($this->mcrypt));
     }
 
     /**
@@ -83,7 +83,7 @@ abstract class AbstractMcryptMixer extends AbstractMixer
     public function __destruct()
     {
         if ($this->mcrypt) {
-            mcrypt_module_close($this->mcrypt);
+            @mcrypt_module_close($this->mcrypt);
         }
     }
 


### PR DESCRIPTION
FIXED: FUNCTION MCYRPT_XXX IS DEPRECATED with PHP 7.1-RC in MAC OSX

check line 75,76,77 and 86