### PR TITLE
Fix XORMixer double XOR issue

### DIFF
--- a/lib/RandomLib/Mixer/XorMixer.php
+++ b/lib/RandomLib/Mixer/XorMixer.php
@@ -10,14 +10,9 @@
  */
 
 /**
- * The Hash medium strength mixer class
- *
- * This class implements a mixer based upon the recommendations in RFC 4086
- * section 5.2
+ * XOR mixer
  *
  * PHP version 5.3
- *
- * @see        http://tools.ietf.org/html/rfc4086#section-5.2
  *
  * @category   PHPCryptLib
  * @package    Random
@@ -34,12 +29,7 @@ namespace RandomLib\Mixer;
 use SecurityLib\Strength;
 
 /**
- * The Hash medium strength mixer class
- *
- * This class implements a mixer based upon the recommendations in RFC 4086
- * section 5.2
- *
- * @see        http://tools.ietf.org/html/rfc4086#section-5.2
+ * XOR mixer
  *
  * @category   PHPCryptLib
  * @package    Random
@@ -51,7 +41,7 @@ class XorMixer extends \RandomLib\AbstractMixer
 {
 
     /**
-     * Return an instance of Strength indicating the strength of the source
+     * Return an instance of Strength indicating the strength of the mixer
      *
      * @return \SecurityLib\Strength An instance of one of the strength classes
      */
@@ -90,7 +80,10 @@ class XorMixer extends \RandomLib\AbstractMixer
      */
     protected function mixParts1($part1, $part2)
     {
-        return $part1 ^ $part2;
+        // The XOR operation is done in AbstractMixer; repeating it here will
+        // cause the previous source to get XORed with itself, setting it to
+        // zero
+        return $part2;
     }
 
     /**
@@ -104,6 +97,6 @@ class XorMixer extends \RandomLib\AbstractMixer
     protected function mixParts2($part1, $part2)
     {
         // Both mixers are identical, this is for speed, not security
-        return $part1 ^ $part2;
+        return $part2;
     }
 }

--- a/test/Unit/RandomLib/Mixer/XorMixerTest.php
+++ b/test/Unit/RandomLib/Mixer/XorMixerTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * The RandomLib library for securely generating random numbers and strings in PHP
+ *
+ * @author     Anthony Ferrara <ircmaxell@ircmaxell.com>
+ * @copyright  2011 The Authors
+ * @license    http://www.opensource.org/licenses/mit-license.html  MIT License
+ * @version    Build @@version@@
+ */
+namespace RandomLib\Mixer;
+
+use SecurityLib\Strength;
+
+class XorMixerTest extends \PHPUnit_Framework_TestCase
+{
+    public static function provideMix()
+    {
+        $data = array(
+            array(array(), ''),
+            array(array('1', '1'), '00'),
+            array(array('a'), '61'),
+            array(array('a', 'b'), '03'),
+            array(array('aa', 'ba'), '0300'),
+            array(array('ab', 'bb'), '0300'),
+            array(array('aa', 'bb'), '0303'),
+            array(array('aa', 'bb', 'cc'), '6060'),
+            array(array('aabbcc', 'bbccdd', 'ccddee'), '606065656262'),
+        );
+
+        return $data;
+    }
+
+    public function testConstructWithoutArgument()
+    {
+        $xorMixer = new XorMixer();
+        $this->assertTrue($xorMixer instanceof \RandomLib\Mixer);
+    }
+
+    public function testGetStrength()
+    {
+        $strength = new Strength(Strength::VERYLOW);
+        $actual = XorMixer::getStrength();
+        $this->assertEquals($actual, $strength);
+    }
+
+    public function testTest()
+    {
+        $actual = XorMixer::test();
+        $this->assertTrue($actual);
+    }
+
+    /**
+     * @dataProvider provideMix
+     */
+    public function testMix($parts, $result)
+    {
+        $mixer = new XorMixer();
+        $actual = $mixer->mix($parts);
+        $this->assertSame($result, bin2hex($actual));
+    }
+}


### PR DESCRIPTION
This pull request fixes an issue where an XOR operation is done in both AbstractMixer and XORMixer, causing the source from the previous iteration to get XORed with itself, setting it to zero. This in turn causes XORMixer to always return the last source verbatim.

`AbstractMixer::mix()` contains the following code:
```php
if ($j % 2 == 1) {
    $stub ^= $this->mixParts1($stub, $newKey);
} else {
    $stub ^= $this->mixParts2($stub, $newKey);
}
```

By inlining `XorMixer::mixParts1()` and `XorMixer::mixParts2()`, we get:
```php
if ($j % 2 == 1) {
    $stub = $stub ^ $stub ^ $newKey;
} else {
    $stub = $stub ^ $stub ^ $newKey;
}
```

which is equivalent to:
```php
if ($j % 2 == 1) {
    $stub = $newKey;
} else {
    $stub = $newKey;
}
```